### PR TITLE
Feature/flush collector

### DIFF
--- a/src/Prometheus/CollectorRegistry.php
+++ b/src/Prometheus/CollectorRegistry.php
@@ -38,6 +38,7 @@ class CollectorRegistry
 
     /**
      * CollectorRegistry constructor.
+     *
      * @param Adapter $redisAdapter
      */
     public function __construct(Adapter $redisAdapter)
@@ -236,6 +237,14 @@ class CollectorRegistry
             $histogram = $this->registerHistogram($namespace, $name, $help, $labels, $buckets);
         }
         return $histogram;
+    }
+
+    public function flush()
+    {
+        $this->storageAdapter->flush();
+        $this->counters = [];
+        $this->gauges = [];
+        $this->histograms = [];
     }
 
     /**

--- a/src/Prometheus/Storage/APC.php
+++ b/src/Prometheus/Storage/APC.php
@@ -97,7 +97,7 @@ class APC implements Adapter
     /**
      * @return void
      */
-    public function flushAPC()
+    public function flush()
     {
         apcu_clear_cache();
     }

--- a/src/Prometheus/Storage/Adapter.php
+++ b/src/Prometheus/Storage/Adapter.php
@@ -34,4 +34,9 @@ interface Adapter
      * @return void
      */
     public function updateCounter(array $data);
+
+    /**
+     * @return void
+     */
+    public function flush();
 }

--- a/src/Prometheus/Storage/InMemory.php
+++ b/src/Prometheus/Storage/InMemory.php
@@ -25,7 +25,7 @@ class InMemory implements Adapter
         return $metrics;
     }
 
-    public function flushMemory()
+    public function flush()
     {
         $this->counters = [];
         $this->gauges = [];

--- a/src/Prometheus/Storage/Redis.php
+++ b/src/Prometheus/Storage/Redis.php
@@ -89,7 +89,7 @@ class Redis implements Adapter
     /**
      * @throws StorageException
      */
-    public function flushRedis()
+    public function flush()
     {
         $this->openConnection();
         $this->redis->flushAll();

--- a/tests/Test/Prometheus/APC/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/APC/CollectorRegistryTest.php
@@ -14,6 +14,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/CounterTest.php
+++ b/tests/Test/Prometheus/APC/CounterTest.php
@@ -14,6 +14,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/GaugeTest.php
+++ b/tests/Test/Prometheus/APC/GaugeTest.php
@@ -14,6 +14,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/APC/HistogramTest.php
+++ b/tests/Test/Prometheus/APC/HistogramTest.php
@@ -14,6 +14,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new APC();
-        $this->adapter->flushAPC();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/InMemory/CollectorRegistryTest.php
@@ -10,6 +10,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/CounterTest.php
+++ b/tests/Test/Prometheus/InMemory/CounterTest.php
@@ -14,6 +14,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/GaugeTest.php
+++ b/tests/Test/Prometheus/InMemory/GaugeTest.php
@@ -14,6 +14,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/InMemory/HistogramTest.php
+++ b/tests/Test/Prometheus/InMemory/HistogramTest.php
@@ -14,6 +14,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new InMemory();
-        $this->adapter->flushMemory();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/PushGatewayTest.php
+++ b/tests/Test/Prometheus/PushGatewayTest.php
@@ -3,9 +3,8 @@
 namespace Test\Prometheus;
 
 use GuzzleHttp\Client;
-use GuzzleHttp\Handler\MockHandler;
-use GuzzleHttp\HandlerStack;
-use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Message\Response;
+use GuzzleHttp\Ring\Client\MockHandler;
 use PHPUnit\Framework\TestCase;
 use Prometheus\CollectorRegistry;
 use Prometheus\MetricFamilySamples;
@@ -25,12 +24,8 @@ class PushGatewayTest extends TestCase
             $this->createMock(MetricFamilySamples::class)
         ]);
 
-        $mockHandler = new MockHandler([
-            new Response(200),
-            new Response(202),
-        ]);
-        $handler = HandlerStack::create($mockHandler);
-        $client = new Client(['handler' => $handler]);
+        $mockHandler = new MockHandler(['status' => 200]);
+        $client = new Client(['handler' => $mockHandler]);
 
         $pushGateway = new PushGateway('http://foo.bar', $client);
         $pushGateway->push($mockedCollectorRegistry, 'foo');
@@ -50,12 +45,13 @@ class PushGatewayTest extends TestCase
             $this->createMock(MetricFamilySamples::class)
         ]);
 
+
         $mockHandler = new MockHandler([
             new Response(201),
             new Response(300),
         ]);
-        $handler = HandlerStack::create($mockHandler);
-        $client = new Client(['handler' => $handler]);
+
+        $client = new Client(['handler' => $mockHandler]);
 
         $pushGateway = new PushGateway('http://foo.bar', $client);
         $pushGateway->push($mockedCollectorRegistry, 'foo');

--- a/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
+++ b/tests/Test/Prometheus/Redis/CollectorRegistryTest.php
@@ -13,6 +13,6 @@ class CollectorRegistryTest extends AbstractCollectorRegistryTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterTest.php
+++ b/tests/Test/Prometheus/Redis/CounterTest.php
@@ -14,6 +14,6 @@ class CounterTest extends AbstractCounterTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/CounterWithPrefixTest.php
@@ -19,6 +19,6 @@ class CounterWithPrefixTest extends AbstractCounterTest
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeTest.php
@@ -14,6 +14,6 @@ class GaugeTest extends AbstractGaugeTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/GaugeWithPrefixTest.php
@@ -19,6 +19,6 @@ class GaugeWithPrefixTest extends AbstractGaugeTest
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramTest.php
@@ -14,6 +14,6 @@ class HistogramTest extends AbstractHistogramTest
     public function configureAdapter()
     {
         $this->adapter = new Redis(['host' => REDIS_HOST]);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
+++ b/tests/Test/Prometheus/Redis/HistogramWithPrefixTest.php
@@ -19,6 +19,6 @@ class HistogramWithPrefixTest extends AbstractHistogramTest
         $connection->setOption(\Redis::OPT_PREFIX, 'prefix:');
 
         $this->adapter = Redis::fromExistingConnection($connection);
-        $this->adapter->flushRedis();
+        $this->adapter->flush();
     }
 }

--- a/tests/Test/Prometheus/Storage/RedisTest.php
+++ b/tests/Test/Prometheus/Storage/RedisTest.php
@@ -21,7 +21,7 @@ class RedisTest extends TestCase
         $this->expectExceptionMessage("Can't connect to Redis server");
 
         $redis->collect();
-        $redis->flushRedis();
+        $redis->flush();
     }
 
     /**


### PR DESCRIPTION
This PR:
- adds a `flush` method to the storage interface, previously it was separate for each class like `flushRedis` or `flushMemory`.
- adds a `flush` method to the `CollectorRegistry` in order to expose the functionality to reset it.
